### PR TITLE
removed jQuery and allowed for multiple compareTo elements, closes #1

### DIFF
--- a/compareTo.js
+++ b/compareTo.js
@@ -1,17 +1,45 @@
-$(function() {
-  var confirm_password = $("input[compareTo]");
-  var comparateName = confirm_password.attr("compareTo");
-  var password = $("input[name=" + comparateName + "]");
+function validatePassword(target, validator) {  
+	if( validator.value !== target.value ) {
+		validator.setCustomValidity("These passwords don't match.");
+	} else {
+		validator.setCustomValidity('');
+	}
 
-  function validatePassword() {
-    if (confirm_password.val() !== password.val()) {
-      confirm_password.get(0).setCustomValidity("These passwords don't match.");
-    } else {
-      confirm_password.get(0).setCustomValidity('');
-    }
-  }
+}
 
-  confirm_password.on("change", validatePassword)
-  password.on("change", validatePassword);
 
-});
+function setCompareTo() {  //sets up all elements of compareTo
+	var allInputs = document.getElementsByTagName('input');
+	for( var i=0; i<allInputs.length; i++ ) {
+
+		if ( allInputs[i].hasAttribute('compareTo') ) {
+			var targetname = allInputs[i].getAttribute('compareTo');
+			var target = document.getElementsByName(targetname);
+
+			if( target.length === 1 ) {  //make sure we reference exactly one element
+				allInputs[i].addEventListener("change", (function(target, validator) {  //closure loop
+						return function(){
+							validatePassword(target, validator);
+						};
+					})(target[0], allInputs[i])
+				);
+
+				target[0].addEventListener("change", (function(target, validator) {  //closure loop
+						return function(){
+							validatePassword(target, validator);
+						};
+					})(target[0], allInputs[i])
+				);
+				
+
+			}
+
+		}
+	
+
+	}
+}
+
+
+
+setCompareTo();  //search for compareTo inputs and activate them


### PR DESCRIPTION
Closes issue #1 , additionally allows for multple compareTo elements see below

<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Document</title>
</head>
<body>

  <!-- This form does not do anything particularly interesting, just 
  demonstrate the compareTo attribute. -->

  <form>

```
<span>Password:</span>
<input type="password" name="password" required>
<br>
<span>Confirm password:</span>
<input type="password" name="compare_password" compareTo="password" required>
<br>

<span>Password2:</span>
<input type="password" name="password2" required>
<br>
<span>Confirm password2:</span>
<input type="password" name="compare_password2" compareTo="password2" required>
<br>

<span>Password:</span>
<input type="password" name="password3" required>
<br>
<span>Confirm password:</span>
<input type="password" name="compare_password3" compareTo="password3" required>
<br>




<input type="submit">
```

  </form>

  <!-- <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script> -->
  <script src="compareTo.js"></script>
</body>
</html>
